### PR TITLE
Leerzeichen eingefügt

### DIFF
--- a/strings/strings.po
+++ b/strings/strings.po
@@ -58483,7 +58483,7 @@ msgid ""
 "Wire</style> can result in damage to the circuit"
 msgstr ""
 "Sendet ein <style=\"KKeyword\">Automatisierungssignal</style> mit einer "
-"höheren <style=\"KKeyword\">Bit Depth</style> als der angeschlossene<style="
+"höheren <style=\"KKeyword\">Bit Depth</style> als der angeschlossene <style="
 "\"KKeyword\">Logikdraht</style>. Kann zur Beschädigung des Kreises führen"
 
 #. STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.MAX_WATTAGE


### PR DESCRIPTION
Automatisierungsdraht - Beschreibung:
- Bit Depth (Mouseover): Sendet ein Automatisierungssignal mit einer höheren Bit Depth als der 
- vorher: angeschlosseneLogikdraht
- nachher: angeschlossene Logikdraht