### PR TITLE
Viele Kommazeichen und Großkleinschreibung

### DIFF
--- a/strings/strings.po
+++ b/strings/strings.po
@@ -202,7 +202,7 @@ msgid ""
 "\n"
 "Bait material is set during the construction of the building"
 msgstr ""
-"Als Köder wird {0} verwendet-\n"
+"Als Köder wird {0} verwendet\n"
 "\n"
 "Der Köder wird während des Baus des Gebäudes festgelegt"
 
@@ -412,7 +412,7 @@ msgid ""
 "more effectively quarantine sick Duplicants"
 msgstr ""
 "Baue diese medizinische Ausrüstung in einem <style=\"KKeyword\">Krankenhaus</"
-"style> um deine Duplikanten besser unter Quarantäne stellen zu können"
+"style>, um deine Duplikanten besser unter Quarantäne stellen zu können"
 
 #. STRINGS.BUILDING.STATUSITEMS.COLONYLACKSREQUIREDSKILLPERK.NAME
 #, fuzzy
@@ -869,7 +869,7 @@ msgid ""
 "color> to view this light's visibility radius"
 msgstr ""
 "Öffne das <b>Licht-Overlay</b> <b><color=#F44A4A>[{LightGridOverlay}]</b></"
-"color> um den Radius dieser Lampe zu sehen"
+"color>, um den Radius dieser Lampe zu sehen"
 
 #. STRINGS.BUILDING.STATUSITEMS.EMITTINGOXYGENAVG.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.EMITTINGOXYGENAVG.NAME"
@@ -1215,7 +1215,7 @@ msgstr ""
 "<link=\"DIRTYWATER\">Verschmutztes Wasser</link> muss aus diesem <link="
 "\"ALGAEHABITAT\">Algen-Terrarium</link> entleert werden.\n"
 "------------------\n"
-"<link=\"BOTTLEEMPTIER\">Flaschen-Entleerer</link> können verwendet werden um "
+"<link=\"BOTTLEEMPTIER\">Flaschen-Entleerer</link> können verwendet werden, um "
 "<link=\"DIRTYWATER\">verschmutzten Wassers</link> aus bestimmten Gebieten "
 "abzutransportieren und zu entsorgen"
 
@@ -1849,7 +1849,7 @@ msgstr "Keine Samen"
 #. STRINGS.BUILDING.STATUSITEMS.NEEDPLANT.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.NEEDPLANT.TOOLTIP"
 msgid "Uproot wild plants to obtain seeds"
-msgstr "Entwurzle Wildpflanzen um Samen zu erhalten"
+msgstr "Entwurzle Wildpflanzen, um Samen zu erhalten"
 
 #. STRINGS.BUILDING.STATUSITEMS.NEEDPOWER.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.NEEDPOWER.NAME"
@@ -1906,7 +1906,7 @@ msgstr "Kein Samen ausgewählt"
 #. STRINGS.BUILDING.STATUSITEMS.NEEDSEED.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.NEEDSEED.TOOLTIP"
 msgid "Uproot wild plants to obtain seeds"
-msgstr "Entwurzle Wildpflanzen um Samen zu erhalten"
+msgstr "Entwurzle Wildpflanzen, um Samen zu erhalten"
 
 #. STRINGS.BUILDING.STATUSITEMS.NEEDSOLIDIN.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.NEEDSOLIDIN.NAME"
@@ -2226,7 +2226,7 @@ msgid ""
 "Open the <b>Research Tree</b> <b><color=#F44A4A>[R]</b></color> to select a "
 "new <link=\"TECH\">Research</link> project"
 msgstr ""
-"Öffne den <b>Forschungsbaum</b> <b><color=#F44A4A>[R]</b></color> um ein neues "
+"Öffne den <b>Forschungsbaum</b> <b><color=#F44A4A>[R]</b></color>, um ein neues "
 "<link=\"TECH\">Forschungsprojekt</link> zu wählen"
 
 #. STRINGS.BUILDING.STATUSITEMS.NORESEARCHSELECTED.TOOLTIP
@@ -2235,7 +2235,7 @@ msgid ""
 "Open the <b>Research Tree</b> <b><color=#F44A4A>[R]</b></color> to select a "
 "new <link=\"TECH\">Research</link> project"
 msgstr ""
-"Öffne den <b>Forschungsbaum</b> <b><color=#F44A4A>[R]</b></color> um ein neues "
+"Öffne den <b>Forschungsbaum</b> <b><color=#F44A4A>[R]</b></color>, um ein neues "
 "<link=\"TECH\">Forschungsprojekt</link> zu wählen"
 
 #. STRINGS.BUILDING.STATUSITEMS.NORMAL.NAME
@@ -2650,7 +2650,7 @@ msgid ""
 msgstr ""
 "Diese Einrichtung ist ausgeschaltet\n"
 "Drücke <style=\"KKeyword\">Aktivieren</style> <b><color=#F44A4A>[ENTER]</b></"
-"color> um es weiter zu verwenden"
+"color>, um es weiter zu verwenden"
 
 #. STRINGS.BUILDING.STATUSITEMS.POWERLOOPDETECTED.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.POWERLOOPDETECTED.NAME"
@@ -2947,7 +2947,7 @@ msgid ""
 "This dock does not contain enough <link=\"PETROLEUM\">Petroleum</link> to "
 "refill a <style=\"KKeyword\">Suit</style>"
 msgstr ""
-"Dieses Dock hat nicht genug <link=\"PETROLEUM\">Petroleum</link> um einen "
+"Dieses Dock hat nicht genug <link=\"PETROLEUM\">Petroleum</link>, um einen "
 "<style=\"KKeyword\">Anzug</style> aufzufüllen"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NO_OXYGEN.NAME
@@ -2961,7 +2961,7 @@ msgid ""
 "This dock does not contain enough <link=\"OXYGEN\">Oxygen</link> to refill a "
 "<style=\"KKeyword\">Suit</style>"
 msgstr ""
-"Dieses Dock hat nicht genug <link=\"OXYGEN\">Sauerstoff</link> um einen <style="
+"Dieses Dock hat nicht genug <link=\"OXYGEN\">Sauerstoff</link>, um einen <style="
 "\"KKeyword\">Anzug</style> aufzufüllen"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NOT_OPERATIONAL.NAME
@@ -3306,7 +3306,7 @@ msgid ""
 "<b>{Active_Temperature}</b> in order to produce power"
 msgstr ""
 "Diese Turbine benötigt {Src_Element} mit einer minimalen Temperatur von "
-"<b>{Active_Temperature}</b> um Strom zu erzeugen"
+"<b>{Active_Temperature}</b>, um Strom zu erzeugen"
 
 #. STRINGS.BUILDING.STATUSITEMS.TURBINE_PARTIALLY_BLOCKED_INPUT.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.TURBINE_PARTIALLY_BLOCKED_INPUT.NAME"
@@ -3362,7 +3362,7 @@ msgstr "Nicht zugewiesen"
 #. STRINGS.BUILDING.STATUSITEMS.UNASSIGNED.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.UNASSIGNED.TOOLTIP"
 msgid "Assign a Duplicant to use this amenity"
-msgstr "Weise einen Duplikanten zu um diese Einrichtung zu benutzen"
+msgstr "Weise einen Duplikanten an, diese Einrichtung zu benutzen"
 
 #. STRINGS.BUILDING.STATUSITEMS.UNDERCONSTRUCTION.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.UNDERCONSTRUCTION.NAME"
@@ -3426,7 +3426,7 @@ msgstr "Angeforderte Flussrate: {QueuedMaxFlow}"
 #. STRINGS.BUILDING.STATUSITEMS.VALVEREQUEST.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.VALVEREQUEST.TOOLTIP"
 msgid "Waiting for a Duplicant to adjust flow rate"
-msgstr "Warte auf einen Duplikanten um Flussrate zu justieren"
+msgstr "Warte auf einen Duplikanten, um die Flussrate zu justieren"
 
 #. STRINGS.BUILDING.STATUSITEMS.WAITINGFORMATERIALS.LINE_ITEM_MASS
 msgctxt "STRINGS.BUILDING.STATUSITEMS.WAITINGFORMATERIALS.LINE_ITEM_MASS"
@@ -3897,7 +3897,7 @@ msgid ""
 "\">Polluted Oxygen</link> from the air, reducing <link=\"DISEASE\">Disease</"
 "link> spread."
 msgstr ""
-"Nutzt <link=\"SAND\">Sand</link> um <link=\"CONTAMINATEDOXYGEN\">verschmutzten "
+"Nutzt <link=\"SAND\">Sand</link>, um <link=\"CONTAMINATEDOXYGEN\">verschmutzten "
 "Sauerstoff</link> aus der Luft zu filtern, und die Verbreitung von <link="
 "\"DISEASE\">Krankheiten</link> zu reduzieren."
 
@@ -3942,7 +3942,7 @@ msgid ""
 "\n"
 "Gains a 10% efficiency boost in direct <link=\"LIGHT\">Light</link>."
 msgstr ""
-"Verbraucht <link=\"ALGAE\">Algen</link> um <link=\"OXYGEN\">Sauerstoff</link> "
+"Verbraucht <link=\"ALGAE\">Algen</link>, um <link=\"OXYGEN\">Sauerstoff</link> "
 "zu produzieren und entfernt ein wenig <link=\"CARBONDIOXIDE"
 "\">Kohlenstoffdioxid</link>.\n"
 "\n"
@@ -4372,7 +4372,7 @@ msgid ""
 "\n"
 "Can withstand extreme pressures and impacts."
 msgstr ""
-"Wird verwendet um Wände und Böden für Räume zu bauen.\n"
+"Wird verwendet, um Wände und Böden für Räume zu bauen.\n"
 "\n"
 "Kann extremem Druck und Einschlägen standhalten."
 
@@ -4577,7 +4577,7 @@ msgid ""
 "Increases <link=\"DECOR\">Decor</link>, contributing to <link=\"MORALE"
 "\">Morale</link>."
 msgstr ""
-"Wird verwendet um Wände und Böden für Räume zu bauen.\n"
+"Wird verwendet, um Wände und Böden für Räume zu bauen.\n"
 "\n"
 "Erhöht <link=\"DECOR\">Dekoration</link> und trägt damit zu <link=\"MORALE"
 "\">Moral</link> bei."
@@ -4695,7 +4695,7 @@ msgid ""
 "Uses <link=\"WATER\">Water</link> to filter <link=\"CARBONDIOXIDE\">Carbon "
 "Dioxide</link> from the air."
 msgstr ""
-"Benutzt <link=\"WATER\">Wasser</link> um <link=\"CARBONDIOXIDE"
+"Benutzt <link=\"WATER\">Wasser</link>, um <link=\"CARBONDIOXIDE"
 "\">Kohlenstoffdioxid</link> aus der Luft zu filtern."
 
 #. STRINGS.BUILDINGS.PREFABS.CO2SCRUBBER.NAME
@@ -5177,7 +5177,7 @@ msgctxt "STRINGS.BUILDINGS.PREFABS.DOOR.DESC"
 msgid ""
 "Door controls can be used to prevent Duplicants from entering restricted areas."
 msgstr ""
-"Türkontrollen können verwendet werden um zu verhindern, dass Duplikanten in "
+"Türkontrollen können verwendet werden, um zu verhindern, dass Duplikanten in "
 "gewisse Bereiche gelangen."
 
 #. STRINGS.BUILDINGS.PREFABS.DOOR.EFFECT
@@ -5484,7 +5484,7 @@ msgid ""
 "\">Fertilizer</link>."
 msgstr ""
 "Verbraucht <link=\"DIRTYWATER\">verschmutztes Wasser</link> und <link="
-"\"PHOSPHORITE\">Phosphorit</link> um <link=\"FERTILIZER\">Dünger</link> "
+"\"PHOSPHORITE\">Phosphorit</link>, um <link=\"FERTILIZER\">Dünger</link> "
 "herzustellen."
 
 #. STRINGS.BUILDINGS.PREFABS.FERTILIZERMAKER.NAME
@@ -6286,7 +6286,7 @@ msgid ""
 "Blocks <link=\"ELEMENTSLIQUID\">Liquid</link> flow without obstructing <link="
 "\"ELEMENTSGAS\">Gas</link>."
 msgstr ""
-"Wird verwendet um Wände und Böden für Räume zu bauen.\n"
+"Wird verwendet, um Wände und Böden für Räume zu bauen.\n"
 "\n"
 "Lässt keine <link=\"ELEMENTSLIQUID\">Flüssigkeiten</link> durch, aber dafür "
 "<link=\"ELEMENTSGAS\">Gas</link> durch."
@@ -6370,7 +6370,7 @@ msgid ""
 "Releases <link=\"ELEMENTSGAS\">Gas</link> from <link=\"GASPIPING\">Gas Pipes</"
 "link>."
 msgstr ""
-"Ein Auslass um <link=\"GASPIPING\">Gas</link> aus <link=\"GASPIPING"
+"Ein Auslass, um <link=\"GASPIPING\">Gas</link> aus <link=\"GASPIPING"
 "\">Gasleitungen</link> zu leiten."
 
 #. STRINGS.BUILDINGS.PREFABS.GASVENT.NAME
@@ -6516,7 +6516,7 @@ msgid ""
 "Allows <link=\"LIGHT\">Light</link> and <link=\"DECOR\">Decor</link> to pass "
 "through."
 msgstr ""
-"Wird verwendet um Wände und Böden für Räume zu bauen.\n"
+"Wird verwendet, um Wände und Böden für Räume zu bauen.\n"
 "\n"
 "Lässt <link=\"LIGHT\">Licht</link> und <link=\"DECOR\">Dekoration</link> durch."
 
@@ -6967,7 +6967,7 @@ msgid ""
 "Reduces <link=\"HEAT\">Heat</link> transfer between walls, retaining ambient "
 "heat in an area."
 msgstr ""
-"Wird verwendet um Wände und Böden für Räume zu bauen.\n"
+"Wird verwendet, um Wände und Böden für Räume zu bauen.\n"
 "\n"
 "Reduziert den <link=\"HEAT\">Temperaturtransfer</link> zwischen Wänden, hält "
 "die Umgebungswärme in einem Gebiet."
@@ -7893,7 +7893,7 @@ msgstr ""
 #. STRINGS.BUILDINGS.PREFABS.LOGICCOUNTER.INPUT_PORT_ACTIVE
 msgctxt "STRINGS.BUILDINGS.PREFABS.LOGICCOUNTER.INPUT_PORT_ACTIVE"
 msgid "<b><style=\"logic_on\">Green Signal</style></b>: Increase counter by one"
-msgstr "<b><style=\"logic_on\">Grünes Signal</style></b>: erhöht Zähler um eins"
+msgstr "<b><style=\"logic_on\">Grünes Signal</style></b>: Erhöht Zähler um eins"
 
 #. STRINGS.BUILDINGS.PREFABS.LOGICCOUNTER.INPUT_PORT_INACTIVE
 msgctxt "STRINGS.BUILDINGS.PREFABS.LOGICCOUNTER.INPUT_PORT_INACTIVE"
@@ -9415,7 +9415,7 @@ msgstr "<link =\"LOGICWATTSENSOR\">Leistungssensor</link>"
 msgctxt "STRINGS.BUILDINGS.PREFABS.LOGICWIRE.DESC"
 msgid "Automation wire is used to connect building ports to automation gates."
 msgstr ""
-"Automatisierungsdraht werden benutzt, um m Gebäudeanschlüsse mit "
+"Automatisierungsdraht wird benutzt, um Gebäudeanschlüsse mit "
 "Automatisierungsgattern zu verbinden."
 
 #. STRINGS.BUILDINGS.PREFABS.LOGICWIRE.EFFECT
@@ -9782,7 +9782,7 @@ msgid ""
 "Does not obstruct <link=\"ELEMENTSLIQUID\">Liquid</link> or <link=\"ELEMENTSGAS"
 "\">Gas</link> flow."
 msgstr ""
-"Wird verwendet um Wände und Böden für Räume zu bauen.\n"
+"Wird verwendet, um Wände und Böden für Räume zu bauen.\n"
 "\n"
 "Lässt <link=\"ELEMENTSLIQUID\">Flüssigkeiten</link> und <link=\"ELEMENTSGAS"
 "\">Gase</link> durch."
@@ -9885,7 +9885,7 @@ msgid ""
 "\n"
 "Significantly increases Duplicant runspeed."
 msgstr ""
-"Wird verwendet um Wände und Böden für Räume zu bauen.\n"
+"Wird verwendet, um Wände und Böden für Räume zu bauen.\n"
 "\n"
 "Erhöht die Laufgeschwindigkeit von Duplikanten stark."
 
@@ -10075,7 +10075,7 @@ msgid ""
 "Increases <link=\"DECOR\">Decor</link>, contributing to <link=\"MORALE"
 "\">Morale</link>."
 msgstr ""
-"Wird verwendet um Wände und Böden für Räume zu bauen.\n"
+"Wird verwendet, um Wände und Böden für Räume zu bauen.\n"
 "\n"
 "Erhöht <link=\"DECOR\">Dekoration</link> und trägt damit zu <link=\"MORALE"
 "\">Moral</link> bei."
@@ -10466,7 +10466,7 @@ msgid ""
 "\n"
 "Significantly increases Duplicant runspeed."
 msgstr ""
-"Wird verwendet um Wände und Böden für Räume zu bauen.\n"
+"Wird verwendet, um Wände und Böden für Räume zu bauen.\n"
 "\n"
 "Erhöht die Laufgeschwindigkeit der Duplikanten deutlich."
 
@@ -11160,7 +11160,7 @@ msgid ""
 "link> to prevent spoilage."
 msgstr ""
 "Lagert <link=\"FOOD\">Nahrung</link> bei idealer <link=\"HEAT\">Temperatur</"
-"link> um Verderb zu verhindern."
+"link>, um Verderb zu verhindern."
 
 #. STRINGS.BUILDINGS.PREFABS.REFRIGERATOR.LOGIC_PORT
 msgctxt "STRINGS.BUILDINGS.PREFABS.REFRIGERATOR.LOGIC_PORT"
@@ -12635,7 +12635,7 @@ msgid ""
 "\n"
 "Increases Duplicant runspeed."
 msgstr ""
-"Wird verwendet um Wände und Böden für Räume zu bauen.\n"
+"Wird verwendet, um Wände und Böden für Räume zu bauen.\n"
 "\n"
 "Erhöht die Laufgeschwindigkeit der Duplikanten."
 
@@ -13159,7 +13159,7 @@ msgid ""
 "Produces <link=\"CARBONDIOXIDE\">Carbon Dioxide</link> and <link=\"HEAT"
 "\">Heat</link>."
 msgstr ""
-"Verbrennt <link=\"WOOD\">Holz</link> um elektrische <link=\"POWER\">Energie</"
+"Verbrennt <link=\"WOOD\">Holz</link>, um elektrische <link=\"POWER\">Energie</"
 "link> zu erzeugen.\n"
 "\n"
 "Produziert <link=\"CARBONDIOXIDE\">Kohlendioxid</link> und <link=\"HEAT"
@@ -20302,7 +20302,7 @@ msgstr ""
 "unterwegs sind, Lampenschirmen tragen oder Augenbrauen bei schlafenden "
 "Kollegen anmalen, verbrachten die Studenten Jackie Stern und Olivia Broussard "
 "das Wochenende in ihrem Wohnheim, Erfrischungen und Dekorationen bereit und "
-"warteten auf ihre geehrten Gäste: sich selbst.\n"
+"warteten auf ihre geehrten Gäste: Sich selbst.\n"
 "\n"
 "Die beiden zukünftigen MINT-Studenten, die theoretische Physik mit einem "
 "Schwerpunkt auf dem Funktionieren der Raumzeit studieren, führten das "
@@ -21402,7 +21402,7 @@ msgstr ""
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.EXPAND_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.EXPAND_TOOLTIP"
 msgid "<i>Click to view progress</i>"
-msgstr "<i>Klicken um den Fortschritt anzuzeigen</i>"
+msgstr "<i>Klicken, um den Fortschritt anzuzeigen</i>"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.FRACTIONAL_CYCLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.FRACTIONAL_CYCLE"
@@ -21945,7 +21945,7 @@ msgstr "Kein nahen Tiere"
 #. STRINGS.CREATURES.FERTILITY_MODIFIERS.TEMPERATURE.DESC
 msgctxt "STRINGS.CREATURES.FERTILITY_MODIFIERS.TEMPERATURE.DESC"
 msgid "Body temperature: Between {0} and {1}"
-msgstr "Körpertemperatur: zwischen {0} und {1}"
+msgstr "Körpertemperatur: Zwischen {0} und {1}"
 
 #. STRINGS.CREATURES.FERTILITY_MODIFIERS.TEMPERATURE.NAME
 msgctxt "STRINGS.CREATURES.FERTILITY_MODIFIERS.TEMPERATURE.NAME"
@@ -24192,7 +24192,7 @@ msgstr ""
 "Die <link=\"PLANTS\">Samen</link> einer <link=\"GASGRASS\">Gas Grass</link>-"
 "Pflanze.\n"
 "\n"
-"Wird verwendet um <link=\"MOO\">Gassy Moos</link> zu füttern."
+"Wird verwendet, um <link=\"MOO\">Gassy Moos</link> zu füttern."
 
 #. STRINGS.CREATURES.SPECIES.SEEDS.GASGRASS.NAME
 msgctxt "STRINGS.CREATURES.SPECIES.SEEDS.GASGRASS.NAME"
@@ -26812,7 +26812,7 @@ msgstr ""
 "------------------\n"
 "Duplikanten entwickeln höhere Erwartungen, wenn sich ihre Expertise erhöht"
 
-# Zusätzlicher Zeilenwechsel um die Größe des Tool-Tips zu bereinigen
+# Zusätzlicher Zeilenwechsel, um die Größe des Tooltips zu bereinigen
 #. STRINGS.DUPLICANTS.ATTRIBUTES.QUALITYOFLIFE.DESC
 msgctxt "STRINGS.DUPLICANTS.ATTRIBUTES.QUALITYOFLIFE.DESC"
 msgid ""
@@ -26948,7 +26948,7 @@ msgid ""
 "take to grow back."
 msgstr ""
 "Bestimmt, wie lange Schuppen dieses <style=\"KKeyword\">Tiers</style> "
-"benötigen um nachzuwachsen."
+"benötigen, um nachzuwachsen."
 
 #. STRINGS.DUPLICANTS.ATTRIBUTES.SNEEZYNESS.DESC
 msgctxt "STRINGS.DUPLICANTS.ATTRIBUTES.SNEEZYNESS.DESC"
@@ -27384,7 +27384,7 @@ msgctxt "STRINGS.DUPLICANTS.CHOREGROUPS.RESEARCH.DESC"
 msgid ""
 "Use <style=\"KKeyword\">Research Stations</style> to unlock new technologies."
 msgstr ""
-"Benutzt die <style=\"KKeyword\">Forschungsstationen</style> um neue "
+"Benutzt die <style=\"KKeyword\">Forschungsstationen</style>, um neue "
 "Technologien freizuschalten."
 
 #. STRINGS.DUPLICANTS.CHOREGROUPS.RESEARCH.NAME
@@ -29493,7 +29493,7 @@ msgid ""
 "This Duplicant is uprooting a plant to retrieve a <style=\"KKeyword\">Seed</"
 "style>"
 msgstr ""
-"Dieser Duplikant entwurzelt eine Pflanze um <style=\"KKeyword\">Samen</style> "
+"Dieser Duplikant entwurzelt eine Pflanze, um <style=\"KKeyword\">Samen</style> "
 "zu erhalten"
 
 #. STRINGS.DUPLICANTS.CHORES.USETOILET.NAME
@@ -31970,7 +31970,7 @@ msgstr "Laute Geräusche"
 #. STRINGS.DUPLICANTS.MODIFIERS.NOISEMINOR.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.NOISEMINOR.TOOLTIP"
 msgid "This area is a bit too loud for comfort"
-msgstr "Dieser Bereich ist etwas zu laut um komfortabel zu sein"
+msgstr "Dieser Bereich ist etwas zu laut, um komfortabel zu sein"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.NOISEPEACEFUL.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.NOISEPEACEFUL.NAME"
@@ -32730,7 +32730,7 @@ msgctxt "STRINGS.DUPLICANTS.MODIFIERS.TOOKABREAK.TOOLTIP"
 msgid ""
 "This Duplicant has a bit of time off from work to attend to personal matters"
 msgstr ""
-"Dieser Duplikant hatte etwas Freizeit um sich um persönliche Dinge zu kümmern"
+"Dieser Duplikant hatte etwas Freizeit, um sich um persönliche Dinge zu kümmern"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.TOXICENVIRONMENT.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.TOXICENVIRONMENT.NAME"
@@ -34891,7 +34891,7 @@ msgstr ""
 "    • Keimwiderstand: {Dupe}\n"
 "    • {Severity}: {ExposureLevelBonus}\n"
 "\n"
-"<i>Klicken um zum Ort der letzten Exposition zu springen</i>"
+"<i>Klicken, um zum Ort der letzten Exposition zu springen</i>"
 
 #. STRINGS.DUPLICANTS.STATUSITEMS.FABRICATEDELIVERSTATUS.NAME
 msgctxt "STRINGS.DUPLICANTS.STATUSITEMS.FABRICATEDELIVERSTATUS.NAME"
@@ -35170,7 +35170,7 @@ msgid ""
 "These Duplicants broke buildings to relieve their <style=\"KKeyword\">Stress</"
 "style>:"
 msgstr ""
-"Diese Duplikanten zerstörten Objekte um <style=\"KKeyword\">Stress</style> "
+"Diese Duplikanten zerstörten Objekte, um <style=\"KKeyword\">Stress</style> "
 "abzubauen:"
 
 #. STRINGS.DUPLICANTS.STATUSITEMS.LASHINGOUT.TOOLTIP
@@ -35179,7 +35179,7 @@ msgid ""
 "This Duplicant is breaking buildings to relieve their <style=\"KKeyword"
 "\">Stress</style>"
 msgstr ""
-"Dieser Duplikant zerstört Objekte um <style=\"KKeyword\">Stress</style> "
+"Dieser Duplikant zerstört Objekte, um <style=\"KKeyword\">Stress</style> "
 "abzubauen"
 
 #. STRINGS.DUPLICANTS.STATUSITEMS.LIGHTWORKEFFICIENCYBONUS.NAME
@@ -35388,7 +35388,7 @@ msgstr "Laute Geräusche"
 #. STRINGS.DUPLICANTS.STATUSITEMS.NOISEMINOR.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.STATUSITEMS.NOISEMINOR.TOOLTIP"
 msgid "This area is a bit too loud for comfort"
-msgstr "Dieser Bereich ist etwas zu laut um komfortabel zu sein"
+msgstr "Dieser Bereich ist etwas zu laut, um komfortabel zu sein"
 
 #. STRINGS.DUPLICANTS.STATUSITEMS.NOISEPEACEFUL.NAME
 msgctxt "STRINGS.DUPLICANTS.STATUSITEMS.NOISEPEACEFUL.NAME"
@@ -36895,7 +36895,7 @@ msgstr "Reizdarm"
 msgctxt "STRINGS.DUPLICANTS.TRAITS.MOLEHANDS.DESC"
 msgid "They're great for tunneling, but finding good gloves is a nightmare"
 msgstr ""
-"Diese Hände sind großartig um Tunnel zu graben, aber passende Handschuhe zu "
+"Diese Hände sind großartig, um Tunnel zu graben, aber passende Handschuhe zu "
 "finden ist ein Alptraum"
 
 #. STRINGS.DUPLICANTS.TRAITS.MOLEHANDS.NAME
@@ -38582,7 +38582,7 @@ msgstr ""
 "Energie für eine Änderung der <style=\"KKeyword\">Temperatur</style>, erwärmen "
 "und kühlen sich also langsam ab\n"
 "\n"
-"Spezifische Wärmekapazität: {1} DTU um 1g um 1K zu erwärmen"
+"Spezifische Wärmekapazität: {1} DTU, um 1g um 1K zu erwärmen"
 
 #. STRINGS.ELEMENTS.MATERIAL_MODIFIERS.TOOLTIP.HIGH_THERMAL_CONDUCTIVITY
 msgctxt "STRINGS.ELEMENTS.MATERIAL_MODIFIERS.TOOLTIP.HIGH_THERMAL_CONDUCTIVITY"
@@ -38619,7 +38619,7 @@ msgstr ""
 "wenig Energie für eine Änderung der <style=\"KKeyword\">Temperatur</style>, "
 "erwärmen und kühlen sich also schnell ab\n"
 "\n"
-"Spezifische Wärmekapazität: {1} DTU um 1g um 1K zu erwärmen"
+"Spezifische Wärmekapazität: {1} DTU, um 1g um 1K zu erwärmen"
 
 #. STRINGS.ELEMENTS.MATERIAL_MODIFIERS.TOOLTIP.LOW_THERMAL_CONDUCTIVITY
 msgctxt "STRINGS.ELEMENTS.MATERIAL_MODIFIERS.TOOLTIP.LOW_THERMAL_CONDUCTIVITY"
@@ -44481,7 +44481,7 @@ msgid ""
 "\">Chlorine</link>"
 msgstr ""
 "Der <style=\"KKeyword\">Luftdruck</style> in der Umgebung ist zu hoch für "
-"diesen <link=\"BLEACHSTONE\">Bleichstein</link> um <link=\"CHLORINE\">Chlor</"
+"diesen <link=\"BLEACHSTONE\">Bleichstein</link>, um <link=\"CHLORINE\">Chlor</"
 "link> abzusondern"
 
 #. STRINGS.MISC.STATUSITEMS.BLEACHSTONEBLOCKED.NAME
@@ -44495,7 +44495,7 @@ msgid ""
 "This <link=\"BLEACHSTONE\">Bleachstone</link> deposit has no room to emit "
 "<link=\"CHLORINE\">Chlorine</link>"
 msgstr ""
-"Dieser <link=\"BLEACHSTONE\">Bleichstein</link> hat keinen Platz um <link="
+"Dieser <link=\"BLEACHSTONE\">Bleichstein</link> hat keinen Platz, um <link="
 "\"CHLORINE\">Chlor</link> abzusondern"
 
 #. STRINGS.MISC.STATUSITEMS.BLEACHSTONEEMITTING.NAME
@@ -44521,7 +44521,7 @@ msgid ""
 "\">Chlorine</link>"
 msgstr ""
 "Der <style=\"KKeyword\">Umgebungsdruck</style>ist zu hoch für diesen <link="
-"\"BLEACHSTONE\">Bleichstein</link> um <link=\"CHLORINE\">Chlor</link> "
+"\"BLEACHSTONE\">Bleichstein</link>, um <link=\"CHLORINE\">Chlor</link> "
 "abzusondern"
 
 #. STRINGS.MISC.STATUSITEMS.BURIEDITEM.NAME
@@ -44755,7 +44755,7 @@ msgid ""
 "Use the <b>Harvest Tool</b> <b><color=#F44A4A>[Y]</b></color> to mark this "
 "plant for harvest"
 msgstr ""
-"Benutze das <b>Ernte-Tool</b> <b><color=#F44A4A>[Y]</b></color> um diese "
+"Benutze das <b>Ernte-Tool</b> <b><color=#F44A4A>[Y]</b></color>, um diese "
 "Pflanze für die Ernte zu markieren"
 
 #. STRINGS.MISC.STATUSITEMS.OPERATING.NAME
@@ -44779,7 +44779,7 @@ msgid ""
 "Waiting for a Duplicant to murderize this defenseless <style=\"KKeyword"
 "\">Critter</style>"
 msgstr ""
-"Wartet auf einen Duplikant um diese unbewaffnete <style=\"KKeyword\">Tier</"
+"Wartet auf einen Duplikant, um dieses unbewaffnete <style=\"KKeyword\">Tier</"
 "style> zu ermorden"
 
 #. STRINGS.MISC.STATUSITEMS.ORDERCAPTURE.NAME
@@ -44837,7 +44837,7 @@ msgid ""
 "This <link=\"OXYROCK\">Oxylite</link> deposit is not exposed to air and cannot "
 "emit <link=\"OXYGEN\">Oxygen</link>"
 msgstr ""
-"Diese <link=\"OXYROCK\">Oxilit</link>-Ablagerung hat keinen Platz um <link="
+"Diese <link=\"OXYROCK\">Oxilit</link>-Ablagerung hat keinen Platz, um <link="
 "\"OXYGEN\">Sauerstoff</link> abzugeben"
 
 #. STRINGS.MISC.STATUSITEMS.OXYROCK.OVERPRESSURE.NAME
@@ -44857,7 +44857,7 @@ msgid ""
 "Environmental <style=\"KKeyword\">Gas Pressure</style> is too high for this "
 "<link=\"OXYROCK\">Oxylite</link> deposit to emit <link=\"OXYGEN\">Oxygen</link>"
 msgstr ""
-"Luftdruck ist zu hoch für diese <link=\"OXYROCK\">Oxilit</link>-Ablagerung um "
+"Luftdruck ist zu hoch für diese <link=\"OXYROCK\">Oxilit</link>-Ablagerung, um "
 "<link=\"OXYGEN\">Sauerstoff</link> abzugeben"
 
 #. STRINGS.MISC.STATUSITEMS.OXYROCKBLOCKED.NAME
@@ -44871,7 +44871,7 @@ msgid ""
 "This <link=\"OXYROCK\">Oxylite</link> deposit has no room to emit <link="
 "\"OXYGEN\">Oxygen</link>"
 msgstr ""
-"Diese <link=\"OXYROCK\">Oxilit</link>-Ablagerung hat keinen Platz um <link="
+"Diese <link=\"OXYROCK\">Oxilit</link>-Ablagerung hat keinen Platz, um <link="
 "\"OXYGEN\">Sauerstoff</link> abzugeben"
 
 #. STRINGS.MISC.STATUSITEMS.OXYROCKEMITTING.NAME
@@ -44899,7 +44899,7 @@ msgid ""
 "Environmental <style=\"KKeyword\">Gas Pressure</style> is too high for this "
 "<link=\"OXYROCK\">Oxylite</link> deposit to emit <link=\"OXYGEN\">Oxygen</link>"
 msgstr ""
-"Luftdruck ist zu hoch für diese <link=\"OXYROCK\">Oxilit</link>-Ablagerung um "
+"Luftdruck ist zu hoch für diese <link=\"OXYROCK\">Oxilit</link>-Ablagerung, um "
 "<link=\"OXYGEN\">Sauerstoff</link> abzugeben"
 
 #. STRINGS.MISC.STATUSITEMS.PENDINGCLEAR.NAME
@@ -48167,7 +48167,7 @@ msgctxt "STRINGS.RESEARCH.TECHS.CARGOI.DESC"
 msgid ""
 "Make extra use of journeys into space by mining and storing useful resources."
 msgstr ""
-"Nutze die Reisen ins All um nützliche Ressourcen abzubauen und zu speichern."
+"Nutze die Reisen ins All, um nützliche Ressourcen abzubauen und zu speichern."
 
 #. STRINGS.RESEARCH.TECHS.CARGOI.NAME
 msgctxt "STRINGS.RESEARCH.TECHS.CARGOI.NAME"
@@ -48570,7 +48570,7 @@ msgid ""
 "\">Brine</link> or pull <link=\"CARBONDIOXIDE\">Carbon Dioxide</link> from the "
 "air."
 msgstr ""
-"Verwende gepumpte Flüssigkeiten um <link=\"SALT\">Salz</link> aus <link=\"BRINE"
+"Verwende gepumpte Flüssigkeiten, um <link=\"SALT\">Salz</link> aus <link=\"BRINE"
 "\">Sole</link> zu lösen oder <link=\"CARBONDIOXIDE\">Kohlenstoffdioxid</link> "
 "aus der Luft zu ziehen."
 
@@ -50246,7 +50246,7 @@ msgstr "<link=\"BUILDCATEGORYOXYGEN\">Sauerstoff</link>"
 #. STRINGS.UI.BUILDCATEGORIES.OXYGEN.TOOLTIP
 msgctxt "STRINGS.UI.BUILDCATEGORIES.OXYGEN.TOOLTIP"
 msgid "Everything I need to keep the colony breathing. {Hotkey}"
-msgstr "Alles was ich brauche um die Kolonie in Atem zu halten. {Hotkey}"
+msgstr "Alles was ich brauche, um die Kolonie in Atem zu halten. {Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.PLUMBING.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.PLUMBING.NAME"
@@ -50885,7 +50885,7 @@ msgid ""
 "Decreases <style=\"KKeyword\">Decor</style> values by <b><b>{0}</b></b> in a "
 "<b>{1}</b> tile radius"
 msgstr ""
-"Verringert <style=\"KKeyword\">Dekorationswerte</style> um <b>{0}</b> in einem "
+"Verringert <style=\"KKeyword\">Dekorationswerte</style>, um <b>{0}</b> in einem "
 "Radius von <b>{1}</b>"
 
 #. STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.DECORPROVIDED
@@ -50894,7 +50894,7 @@ msgid ""
 "Improves <style=\"KKeyword\">Decor</style> values by <b><b>{0}</b></b> in a "
 "<b>{1}</b> tile radius"
 msgstr ""
-"Verbessert <style=\"KKeyword\">Dekorationswerte</style> um <b>{0}</b> in einem "
+"Verbessert <style=\"KKeyword\">Dekorationswerte</style>, um <b>{0}</b> in einem "
 "Radius von <b>{1}</b>"
 
 #. STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.DIET_CONSUMED
@@ -51440,7 +51440,7 @@ msgstr ""
 "abgegeben, um das gefertigte Teil abzukühlen\n"
 "\n"
 "Dies wird die <style=\"KKeyword\">Temperatur</style>des enthaltenen <style="
-"\"KKeyword\">{1}</style> um <b>{2}</b> erhöhen und das Gebäude erwärmen"
+"\"KKeyword\">{1}</style>, um <b>{2}</b> erhöhen und das Gebäude erwärmen"
 
 #. STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.REFINEMENT_ENERGY_NO_COOLANT
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.REFINEMENT_ENERGY_NO_COOLANT"
@@ -51484,14 +51484,14 @@ msgctxt "STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.REQUIRESCREATIVITY"
 msgid ""
 "A Duplicant must work on this object to create <style=\"KKeyword\">Art</style>"
 msgstr ""
-"Ein Duplikant muss an diesem Objekt arbeiten um <style=\"KKeyword\">Kunst</"
+"Ein Duplikant muss an diesem Objekt arbeiten, um <style=\"KKeyword\">Kunst</"
 "style> zu erschaffen"
 
 #. STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.REQUIRESELEMENT
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.REQUIRESELEMENT"
 msgid "Must receive deliveries of <style=\"KKeyword\">{0}</style> to function"
 msgstr ""
-"Muss, um zu funktionieren, mit <style=\"KKeyword\">{0}</style> beliefert werden"
+"Muss mit <style=\"KKeyword\">{0}</style> beliefert werden, um zu funktionieren."
 
 #. STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.REQUIRESGASINPUT
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.REQUIRESGASINPUT"
@@ -51790,7 +51790,7 @@ msgid ""
 "Click to go back:\n"
 "N/A"
 msgstr ""
-"Klicke um zurückzukehren zu:\n"
+"Klicke, um zurückzukehren zu:\n"
 "N/A"
 
 #. STRINGS.UI.CODEX.BACK_BUTTON_TOOLTIP
@@ -51799,7 +51799,7 @@ msgid ""
 "Click to go back:\n"
 "{0}"
 msgstr ""
-"Klicke um zurückzukehren zu:\n"
+"Klicke, um zurückzukehren zu:\n"
 "{0}"
 
 #. STRINGS.UI.CODEX.CATEGORYNAMES.BUILDINGS
@@ -51985,7 +51985,7 @@ msgid ""
 "Click to go forward:\n"
 "N/A"
 msgstr ""
-"Klicke um weitermachen:\n"
+"Klicke, um weitermachen:\n"
 "N/A"
 
 #. STRINGS.UI.CODEX.FORWARD_BUTTON_TOOLTIP
@@ -51994,7 +51994,7 @@ msgid ""
 "Click to go forward:\n"
 "{0}"
 msgstr ""
-"Klicke um weitermachen:\n"
+"Klicke, um weitermachen:\n"
 "{0}"
 
 #. STRINGS.UI.CODEX.GAME_SYSTEMS
@@ -52104,7 +52104,7 @@ msgid ""
 "Press <color=#F44A47><b>[ESC]</b></color> to return to a previous colony, or "
 "begin a new one."
 msgstr ""
-"Drücke <color=#F44A47><b>[ESC]</b></color> um zu einer früheren Kolonie "
+"Drücke <color=#F44A47><b>[ESC]</b></color>, um zu einer früheren Kolonie "
 "zurückzukehren oder eine neue zu beginnen."
 
 #. STRINGS.UI.CONFIRMDIALOG.CANCEL
@@ -52707,7 +52707,7 @@ msgctxt "STRINGS.UI.DETAILTABS.DETAILS.MINION_TOOLTIP"
 msgid "More information"
 msgstr "Mehr Informationen"
 
-# gekürtzt um Umbruch zu vermeiden
+# Gekürzt, um Umbruch zu vermeiden
 #. STRINGS.UI.DETAILTABS.DETAILS.NAME
 msgctxt "STRINGS.UI.DETAILTABS.DETAILS.NAME"
 msgid "Properties"
@@ -53750,7 +53750,7 @@ msgstr ""
 "Dieses Gebäude wird überhitzen und Schaden nehmen, wenn seine Temperatur {0} "
 "erreicht.\n"
 "\n"
-"Verwende bessere Materialien um die Überhitzungstemperatur zu erhöhen"
+"Verwende bessere Materialien, um die Überhitzungstemperatur zu erhöhen"
 
 #. STRINGS.UI.ELEMENTAL.PRIMARYELEMENT.NAME
 msgctxt "STRINGS.UI.ELEMENTAL.PRIMARYELEMENT.NAME"
@@ -54208,7 +54208,7 @@ msgstr "Keine"
 #. STRINGS.UI.ENDOFDAYREPORT.NOTES.BUTCHERED
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.NOTES.BUTCHERED"
 msgid "Butchered for {0}"
-msgstr "Geschlachtet um {0} herzustellen"
+msgstr "Geschlachtet, um {0} herzustellen"
 
 #. STRINGS.UI.ENDOFDAYREPORT.NOTES.BUTCHERED_CONTEXT
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.NOTES.BUTCHERED_CONTEXT"
@@ -55958,7 +55958,7 @@ msgid ""
 "<style=\"KKeyword\">These save files will no longer be synced to the cloud.</"
 "style>"
 msgstr ""
-"Konvertieren einer Kolonie um NICHT den Cloud-Speicher zu verwenden, "
+"Konvertieren einer Kolonie, um NICHT den Cloud-Speicher zu verwenden, "
 "verschiebt alle Speicherdateien dieser Kolonie in den lokalen Speicherordner.\n"
 "\n"
 "<style=\"KKeyword\">Diese Speicherstände werden nicht mehr mit der Cloud "
@@ -56862,7 +56862,7 @@ msgstr "ALLE DEAKTIVIEREN"
 #. STRINGS.UI.FRONTEND.MODS.DRAG_TO_REORDER
 msgctxt "STRINGS.UI.FRONTEND.MODS.DRAG_TO_REORDER"
 msgid "Drag to reorder"
-msgstr "Ziehen um neu zu ordnen"
+msgstr "Ziehen, um neu zu ordnen"
 
 #. STRINGS.UI.FRONTEND.MODS.ENABLE_ALL
 msgctxt "STRINGS.UI.FRONTEND.MODS.ENABLE_ALL"
@@ -57099,7 +57099,7 @@ msgctxt "STRINGS.UI.FRONTEND.OPTIONS_SCREEN.TOGGLE_SANDBOX_SCREEN.CONFIRM"
 msgid "Enable Sandbox Mode"
 msgstr "Sandbox-Modus aktivieren"
 
-# etwas gekürzt um einen Zeilenumbruch zu verhindern
+# Etwas gekürzt, um einen Zeilenumbruch zu verhindern
 #. STRINGS.UI.FRONTEND.OPTIONS_SCREEN.TOGGLE_SANDBOX_SCREEN.CONFIRM_SAVE_BACKUP
 msgctxt ""
 "STRINGS.UI.FRONTEND.OPTIONS_SCREEN.TOGGLE_SANDBOX_SCREEN.CONFIRM_SAVE_BACKUP"
@@ -57488,7 +57488,7 @@ msgid ""
 "Please free up some space.\n"
 "{0}"
 msgstr ""
-"Beim Speichern des Spielstands ist ein Fehler aufgetreten: unzureichender "
+"Beim Speichern des Spielstands ist ein Fehler aufgetreten: Unzureichender "
 "Speicherplatz.\n"
 "\n"
 "Bitte machen etwas Platz frei.\n"
@@ -57997,7 +57997,7 @@ msgstr "<link=\"LIGHT\">Licht</link>"
 #. STRINGS.UI.GAMEOBJECTEFFECTS.REQUIRES_PRESSURE
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.REQUIRES_PRESSURE"
 msgid "<link=\"ATMOSPHERE\">Air</link> Pressure: {0} minimum"
-msgstr "<link=\"ATMOSPHERE\">Luftdruck</link>: mindestens {0}"
+msgstr "<link=\"ATMOSPHERE\">Luftdruck</link>: Mindestens {0}"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.REQUIRES_RECEPTACLE
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.REQUIRES_RECEPTACLE"
@@ -58113,7 +58113,7 @@ msgid ""
 "This plant initially takes <b>{0}</b> to grow, but only <b>{1}</b> to mature "
 "after first harvest"
 msgstr ""
-"Diese Pflanze benötigt <b>{0}</b> zum Wachsen, und dann nur <b>{1}</b> um nach "
+"Diese Pflanze benötigt <b>{0}</b> zum Wachsen und dann nur noch <b>{1}</b>, um nach "
 "der ersten Ernte erneut zu reifen"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.TOOLTIPS.GROWTHTIME_SIMPLE
@@ -58127,7 +58127,7 @@ msgid ""
 "This plant requires <b>{1}</b> of <style=\"KKeyword\">{0}</style> for basic "
 "growth"
 msgstr ""
-"Diese Pflanze braucht <b>{1}</b> <style=\"KKeyword\">{0}</style> um zu wachsen"
+"Diese Pflanze braucht <b>{1}</b> <style=\"KKeyword\">{0}</style>, um zu wachsen"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.TOOLTIPS.IDEAL_PRESSURE
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.TOOLTIPS.IDEAL_PRESSURE"
@@ -58144,19 +58144,19 @@ msgid ""
 "This plant requires internal <style=\"KKeyword\">Temperature</style> between "
 "<b>{0}</b> and <b>{1}</b> for basic growth"
 msgstr ""
-"Diese Pflanze braucht eine <style=\"KKeyword\">Temperatur</style>zwischen "
-"<b>{0}</b> und <b>{1}</b> um zu wachsen"
+"Diese Pflanze braucht eine <style=\"KKeyword\">Temperatur</style> zwischen "
+"<b>{0}</b> und <b>{1}</b>, um zu wachsen"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.TOOLTIPS.INITIALGROWTHTIME
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.TOOLTIPS.INITIALGROWTHTIME"
 msgid "This plant takes <b>{0}</b> to mature again once replanted"
 msgstr ""
-"Diese Pflanze benötigt <b>{0}</b> um nach dem Einpflanzen erneut zu reifen"
+"Diese Pflanze benötigt <b>{0}</b>, um nach dem Einpflanzen erneut zu reifen"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.TOOLTIPS.REGROWTHTIME
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.TOOLTIPS.REGROWTHTIME"
 msgid "This plant takes <b>{0}</b> to mature again once harvested"
-msgstr "Diese Pflanze benötigt <b>{0}</b> um nach der Ernte erneut zu reifen"
+msgstr "Diese Pflanze benötigt <b>{0}</b>, um nach der Ernte erneut zu reifen"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.TOOLTIPS.REQUIRES_ATMOSPHERE
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.TOOLTIPS.REQUIRES_ATMOSPHERE"
@@ -59384,7 +59384,7 @@ msgstr "Sauerstoff"
 #. STRINGS.UI.NEWBUILDCATEGORIES.OXYGEN.TOOLTIP
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.OXYGEN.TOOLTIP"
 msgid "Everything you need to keep your colony breathing. {Hotkey}"
-msgstr "Alles was ich brauche um die Kolonie am Atmen zu halten. {Hotkey}"
+msgstr "Alles was ich brauche, um die Kolonie am Atmen zu halten. {Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.PIPES.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.PIPES.BUILDMENUTITLE"
@@ -59686,7 +59686,7 @@ msgstr ""
 "<b>Ausgewachsen</b>\n"
 "Diese Pflanzen sind ausgewachsen\n"
 "------------------\n"
-"Verwende das <b>Erntewerkzeug</b> <b><color=#F44A4A>[Y]</b></color> um sie zu "
+"Verwende das <b>Erntewerkzeug</b> <b><color=#F44A4A>[Y]</b></color>, um sie zu "
 "ernten"
 
 #. STRINGS.UI.OVERLAYS.CROP.TOOLTIPS.GROWING
@@ -59908,7 +59908,7 @@ msgid ""
 msgstr ""
 "<b>Keimquelle</b>\n"
 "Orte an denen Keime produziert werden\n"
-"* Platziere Waschzuber/-becken oder Hand-Desinfizierer in der Nähe um die "
+"* Platziere Waschzuber/-becken oder Hand-Desinfizierer in der Nähe, um die "
 "Krankheitsverbreitung zu vermeiden"
 
 #. STRINGS.UI.OVERLAYS.DISEASE.NAME
@@ -61447,7 +61447,7 @@ msgid ""
 msgstr ""
 "Zählt alle nicht zugewiesenen Ressourcen in Reichweite\n"
 "------------------\n"
-"Klicken um zu erweitern"
+"Klicken, um zu erweitern"
 
 #. STRINGS.UI.RESOURCESCREEN.HEADER
 msgctxt "STRINGS.UI.RESOURCESCREEN.HEADER"
@@ -62946,7 +62946,7 @@ msgid ""
 "Scheduling too few bedtime shifts may prevent my Duplicants from regaining "
 "enough Stamina to make it through the following day."
 msgstr ""
-"Meine Duplikanten nutzen die Schlafenszeit um sich nach einem harten "
+"Meine Duplikanten nutzen die Schlafenszeit, um sich nach einem harten "
 "Arbeitstag zu erholen.\n"
 "\n"
 "Die Planung zu weniger Schlafenszeiten kann meine Duplikanten daran hindern, "
@@ -63847,7 +63847,7 @@ msgid ""
 "A massive volume of <link=\"HYDROGEN\">Hydrogen</link> formed around a small "
 "solid center."
 msgstr ""
-"Ein massives Volumen von <link=\"HYDROGEN\">Wasserstoff</link> das sich um ein "
+"Ein massives Volumen von <link=\"HYDROGEN\">Wasserstoff</link>, das sich um ein "
 "kleines festes Zentrum gebildet hat."
 
 #. STRINGS.UI.SPACEDESTINATIONS.GIANTS.GASGIANT.NAME
@@ -63861,7 +63861,7 @@ msgid ""
 "A massive volume of <link=\"HELIUM\">Helium</link> formed around a small solid "
 "center."
 msgstr ""
-"Ein massives Volumen von <link=\"HELIUM\">Helium</link> das sich um ein "
+"Ein massives Volumen von <link=\"HELIUM\">Helium</link>, das sich um ein "
 "kleines festes Zentrum gebildet hat."
 
 #. STRINGS.UI.SPACEDESTINATIONS.GIANTS.HYDROGENGIANT.NAME
@@ -64854,7 +64854,7 @@ msgstr "<b>{0}</b>"
 #. STRINGS.UI.TABLESCREENS.GOTO_DUPLICANT_BUTTON
 msgctxt "STRINGS.UI.TABLESCREENS.GOTO_DUPLICANT_BUTTON"
 msgid "Double-click to go to <b>{0}</b>"
-msgstr "Doppelklick um zu <b>{0}</b> gelangen"
+msgstr "Doppelklick, um zu <b>{0}</b> gelangen"
 
 # Kontext?
 #. STRINGS.UI.TABLESCREENS.INFORMATION_NOT_AVAILABLE_TOOLTIP
@@ -64870,7 +64870,7 @@ msgstr "N/A"
 #. STRINGS.UI.TABLESCREENS.SELECT_DUPLICANT_BUTTON
 msgctxt "STRINGS.UI.TABLESCREENS.SELECT_DUPLICANT_BUTTON"
 msgid "Click to select <b>{0}</b>"
-msgstr "Klicken um <b>{0}</b> zu selektieren"
+msgstr "Klicken, um <b>{0}</b> zu selektieren"
 
 #. STRINGS.UI.TOOLS.ATTACK.NAME
 msgctxt "STRINGS.UI.TOOLS.ATTACK.NAME"
@@ -66043,7 +66043,7 @@ msgstr "Zeigt Spezialräume und Boni an {Hotkey}"
 #. STRINGS.UI.TOOLTIPS.SELECTAMATERIAL
 msgctxt "STRINGS.UI.TOOLTIPS.SELECTAMATERIAL"
 msgid "There are insufficient materials to construct this building"
-msgstr "Nicht genug Materialien um dieses Objekt zu bauen"
+msgstr "Nicht genug Materialien, um dieses Objekt zu bauen"
 
 #. STRINGS.UI.TOOLTIPS.SORTCOLUMN
 msgctxt "STRINGS.UI.TOOLTIPS.SORTCOLUMN"
@@ -66211,7 +66211,7 @@ msgid ""
 msgstr ""
 "Nach unten durch diese Tür zu steigen ist nicht gestattet\n"
 "\n"
-"Klicke um Zugang zu gewähren"
+"Klicke, um Zugang zu gewähren"
 
 #. STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_DOWN_ENABLED
 msgctxt "STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_DOWN_ENABLED"
@@ -66222,7 +66222,7 @@ msgid ""
 msgstr ""
 "Nach unten durch diese Tür zu steigen ist gestattet\n"
 "\n"
-"Klicke um Zugang zu verwehren"
+"Klicke, um Zugang zu verwehren"
 
 #. STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_LEFT_DISABLED
 msgctxt "STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_LEFT_DISABLED"
@@ -66233,7 +66233,7 @@ msgid ""
 msgstr ""
 "Nach links durch diese Tür zu gehen ist nicht gestattet\n"
 "\n"
-"Klicke um Zugang zu gewähren"
+"Klicke, um Zugang zu gewähren"
 
 #. STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_LEFT_ENABLED
 msgctxt "STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_LEFT_ENABLED"
@@ -66244,7 +66244,7 @@ msgid ""
 msgstr ""
 "Nach links durch diese Tür zu gehen ist gestattet\n"
 "\n"
-"Klicke um Zugang zu verwehren"
+"Klicke, um Zugang zu verwehren"
 
 #. STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_RIGHT_DISABLED
 msgctxt "STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_RIGHT_DISABLED"
@@ -66255,7 +66255,7 @@ msgid ""
 msgstr ""
 "Nach rechts durch diese Tür zu gehen ist nicht gestattet\n"
 "\n"
-"Klicke um Zugang zu gewähren"
+"Klicke, um Zugang zu gewähren"
 
 #. STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_RIGHT_ENABLED
 msgctxt "STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_RIGHT_ENABLED"
@@ -66266,7 +66266,7 @@ msgid ""
 msgstr ""
 "Nach rechts durch diese Tür zu gehen ist gestattet\n"
 "\n"
-"Klicke um Zugang zu verwehren"
+"Klicke, um Zugang zu verwehren"
 
 #. STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_UP_DISABLED
 msgctxt "STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_UP_DISABLED"
@@ -66277,7 +66277,7 @@ msgid ""
 msgstr ""
 "Nach oben durch diese Tür zu steigen ist nicht gestattet\n"
 "\n"
-"Klicke um Zugang zu gewähren"
+"Klicke, um Zugang zu gewähren"
 
 #. STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_UP_ENABLED
 msgctxt "STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.GO_UP_ENABLED"
@@ -66288,7 +66288,7 @@ msgid ""
 msgstr ""
 "Nach oben durch diese Tür zu steigen ist gestattet\n"
 "\n"
-"Klicke um Zugang zu verwehren"
+"Klicke, um Zugang zu verwehren"
 
 #. STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.MINION_ACCESS
 msgctxt "STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.MINION_ACCESS"
@@ -66298,12 +66298,12 @@ msgstr "Duplikanten-Zugangsrechte"
 #. STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.SET_TO_CUSTOM
 msgctxt "STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.SET_TO_CUSTOM"
 msgid "Click to assign custom permissions"
-msgstr "Klicken um eigene Berechtigungen zu setzen"
+msgstr "Klicken, um eigene Berechtigungen zu setzen"
 
 #. STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.SET_TO_DEFAULT
 msgctxt "STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.SET_TO_DEFAULT"
 msgid "Click to clear custom permissions"
-msgstr "Klicken um eigene Berechtigungen zu löschen"
+msgstr "Klicken, um eigene Berechtigungen zu löschen"
 
 #. STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.TITLE
 msgctxt "STRINGS.UI.UISIDESCREENS.ACCESS_CONTROL_SIDE_SCREEN.TITLE"
@@ -67009,7 +67009,7 @@ msgstr "<b>Anforderungen:</b>"
 #. STRINGS.UI.UISIDESCREENS.FABRICATORSIDESCREEN.SELECTRECIPE
 msgctxt "STRINGS.UI.UISIDESCREENS.FABRICATORSIDESCREEN.SELECTRECIPE"
 msgid "Select a recipe to fabricate."
-msgstr "Wähle ein Rezept um die Produktion zu starten."
+msgstr "Wähle ein Rezept, um die Produktion zu starten."
 
 #. STRINGS.UI.UISIDESCREENS.FABRICATORSIDESCREEN.SUBTITLE
 msgctxt "STRINGS.UI.UISIDESCREENS.FABRICATORSIDESCREEN.SUBTITLE"
@@ -69818,7 +69818,7 @@ msgctxt "STRINGS.UI.VICTORYSCREEN.RESTARTPROMPT"
 msgid ""
 "Press <color=#F44A47><b>[ESC]</b></color> to retire the colony and begin anew."
 msgstr ""
-"Drücke <color=#F44A47><b>[ESC]</b></color> um die Kolonie aufzugeben und neu "
+"Drücke <color=#F44A47><b>[ESC]</b></color>, um die Kolonie aufzugeben und neu "
 "anzufangen."
 
 #. STRINGS.UI.VICTORYSCREEN.RETIREBUTTON


### PR DESCRIPTION
Dieser commit beinhaltet hauptsächlich Kommata, z.B.

- alt: "X kann verwendet werden um Y zu tun"
- neu: "X kann verwendet werden, um Y zu tun"

aber auch Großkleinschreibung, meistens nach einem Doppelpunkt

- alt: Grünes Signal: erhöht Zähler um eins
- neu: Grünes Signal: Erhöht Zähler um eins